### PR TITLE
Add robust SFTP sync tool and browser interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+instance/
+.webassets-cache
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# gestor-de-Archivos
+# Gestor de Archivos Orion
+
+Este proyecto proporciona una herramienta de sincronización entre un servidor
+SFTP y un bucket de Amazon S3 junto con una interfaz web ligera que permite
+lanzar el proceso desde el navegador. Está pensado para manejar nombres de
+archivos con caracteres especiales (por ejemplo, `Ñ`) sin provocar errores de
+codificación.
+
+## Requisitos
+
+- Python 3.11 o superior
+- Dependencias listadas en `requirements.txt`
+
+Instala las dependencias con:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # En Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Configuración
+
+La herramienta utiliza variables de entorno para conocer los parámetros de
+conexión y el destino en S3. Puedes definirlas manualmente o a través de un
+archivo `.env` (si usas `python-dotenv`).
+
+Variables principales:
+
+- `SFTP_HOST`: host del servidor SFTP.
+- `SFTP_PORT`: puerto (por defecto `22`).
+- `SFTP_USERNAME` y `SFTP_PASSWORD`: credenciales de acceso.
+- `SFTP_PRIVATE_KEY`: ruta a la clave privada (opcional, alternativa a la contraseña).
+- `SFTP_PASSPHRASE`: passphrase de la clave privada si aplica.
+- `SFTP_BASE_PATH`: carpeta inicial a sincronizar.
+- `SFTP_ENCODINGS`: lista separada por comas con codificaciones a probar (`utf-8,latin-1,cp1252`).
+- `S3_BUCKET`: bucket de destino.
+- `S3_PREFIX`: prefijo (carpeta lógica) dentro del bucket.
+- `AWS_REGION`: región de AWS (opcional).
+- `DELETE_REMOTE_AFTER_UPLOAD`: `true/false` para eliminar el archivo remoto tras subirlo.
+- `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `mp4,mov`).
+
+## Uso por línea de comandos
+
+Carga las variables de entorno y ejecuta:
+
+```bash
+python sync_orion_files.py --env-file .env --verbose
+```
+
+Parámetros disponibles:
+
+- `--env-file`: carga un archivo `.env` con la configuración.
+- `--dry-run`: simula la sincronización sin subir archivos.
+- `--list-only`: solo lista los archivos detectados.
+- `--verbose`: muestra información adicional en los logs.
+
+## Interfaz web
+
+Para lanzar la aplicación web ejecuta:
+
+```bash
+flask --app webapp run
+```
+
+La interfaz estará disponible en `http://127.0.0.1:5000/`. Completa el
+formulario con los parámetros necesarios y pulsa **Ejecutar sincronización**.
+El panel mostrará los registros y el resumen de la ejecución.
+
+> **Nota:** la aplicación reutiliza la misma lógica que la herramienta CLI, por
+> lo que respeta las opciones de codificación para evitar errores de
+> `UnicodeDecodeError` al recorrer el SFTP.
+
+## Pruebas
+
+Puedes verificar rápidamente que el código es válido ejecutando:
+
+```bash
+python -m compileall sync_orion_files.py webapp.py
+```
+
+Esto compila los módulos y ayuda a detectar errores de sintaxis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto3>=1.28,<2.0
+paramiko>=3.3,<4.0
+python-dotenv>=1.0,<2.0
+Flask>=3.0,<4.0

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,140 @@
+:root {
+  --bg-color: #f2f4f8;
+  --card-bg: #ffffff;
+  --accent: #006ad4;
+  --text-color: #1f2933;
+  --muted: #52606d;
+  --error-bg: #ffe0e0;
+  --error-border: #c53030;
+  --success-bg: #e6fffa;
+  font-family: "Segoe UI", Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+.intro {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.field label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.field input[type="text"],
+.field input[type="password"],
+.field input[type="number"] {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #cbd2d9;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+.field input:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 106, 212, 0.15);
+}
+
+.field .hint {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.field.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.field.checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.actions {
+  text-align: right;
+}
+
+.actions button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.8rem 1.6rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.actions button:hover {
+  background: #0053a4;
+}
+
+.card.error {
+  border: 1px solid var(--error-border);
+  background: var(--error-bg);
+}
+
+.card.logs pre {
+  background: #0b1f33;
+  color: #f8fafc;
+  padding: 1rem;
+  border-radius: 10px;
+  max-height: 400px;
+  overflow: auto;
+  font-family: "Fira Mono", Menlo, monospace;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}

--- a/sync_orion_files.py
+++ b/sync_orion_files.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Herramienta para sincronizar archivos de un servidor SFTP a un bucket de S3.
+
+Incluye lógica de tolerancia a diferentes codificaciones de nombres de archivo
+para evitar errores ``UnicodeDecodeError`` durante el recorrido de directorios.
+El módulo expone una API basada en ``run_sync`` que puede reutilizarse desde
+otros contextos (por ejemplo, la interfaz web incluida en ``webapp.py``) y
+mantiene la funcionalidad de ejecución desde la línea de comandos.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+import os
+import posixpath
+import stat
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+import paramiko
+from paramiko.client import SSHClient
+from paramiko.sftp_attr import SFTPAttributes
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - ``python-dotenv`` es opcional.
+    load_dotenv = None
+
+logger = logging.getLogger("sync_orion")
+
+
+@dataclass
+class SyncConfig:
+    """Configuración principal para la sincronización."""
+
+    sftp_host: str
+    sftp_port: int = 22
+    sftp_username: str = ""
+    sftp_password: Optional[str] = None
+    sftp_private_key: Optional[str] = None
+    sftp_passphrase: Optional[str] = None
+    sftp_base_path: str = "."
+    sftp_encodings: Sequence[str] = field(
+        default_factory=lambda: ("utf-8", "latin-1", "cp1252")
+    )
+    s3_bucket: str = ""
+    s3_prefix: str = ""
+    aws_region: Optional[str] = None
+    delete_remote_after_upload: bool = False
+    allowed_extensions: Optional[Sequence[str]] = None
+
+    def normalized_prefix(self) -> str:
+        prefix = self.s3_prefix.strip("/")
+        return prefix
+
+    def remote_base(self) -> str:
+        base = self.sftp_base_path.strip()
+        return base if base else "."
+
+
+@dataclass
+class SyncOptions:
+    """Opciones para modificar el comportamiento de ``run_sync``."""
+
+    dry_run: bool = False
+    list_only: bool = False
+
+
+@dataclass
+class RemoteFile:
+    """Representa un archivo localizado en el servidor remoto."""
+
+    path: str
+    size: int
+    mtime: float
+
+    def relative_to(self, base_path: str) -> str:
+        relative = posixpath.relpath(self.path, base_path)
+        return "." if relative == "." else relative
+
+
+@dataclass
+class SyncSummary:
+    """Resumen de la ejecución de ``run_sync``."""
+
+    encoding_used: str
+    total_remote_files: int
+    uploaded_files: int
+    skipped_existing: int
+    deleted_remote: int
+    dry_run: bool
+    list_only: bool
+
+
+class SyncError(RuntimeError):
+    """Error de alto nivel para fallos durante la sincronización."""
+
+
+def _setup_logger(verbose: bool) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(levelname)s: %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+
+def _load_private_key(config: SyncConfig) -> Optional[paramiko.PKey]:
+    if not config.sftp_private_key:
+        return None
+    key_path = os.path.expanduser(config.sftp_private_key)
+    if not os.path.exists(key_path):
+        raise SyncError(f"La clave privada '{key_path}' no existe")
+    try:
+        return paramiko.RSAKey.from_private_key_file(
+            key_path, password=config.sftp_passphrase
+        )
+    except paramiko.PasswordRequiredException as exc:  # pragma: no cover
+        raise SyncError("Se requiere passphrase para la clave privada") from exc
+    except paramiko.SSHException as exc:  # pragma: no cover
+        raise SyncError(
+            "No se pudo cargar la clave privada proporcionada"
+        ) from exc
+
+
+def _connect_ssh(config: SyncConfig) -> SSHClient:
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    private_key = _load_private_key(config)
+
+    try:
+        client.connect(
+            hostname=config.sftp_host,
+            port=config.sftp_port,
+            username=config.sftp_username or None,
+            password=config.sftp_password or None,
+            pkey=private_key,
+            passphrase=config.sftp_passphrase or None,
+            allow_agent=True,
+            look_for_keys=bool(not config.sftp_private_key),
+        )
+    except paramiko.SSHException as exc:  # pragma: no cover
+        raise SyncError("No se pudo establecer la conexión SSH") from exc
+
+    return client
+
+
+def _create_sftp_client(
+    ssh_client: SSHClient, encoding: str
+) -> paramiko.SFTPClient:
+    transport = ssh_client.get_transport()
+    if transport is None:  # pragma: no cover
+        raise SyncError("No se pudo obtener el transporte SSH")
+    return paramiko.SFTPClient.from_transport(transport, encoding=encoding)
+
+
+def _iter_encodings(config: SyncConfig) -> Iterator[str]:
+    seen = set()
+    for encoding in config.sftp_encodings:
+        encoding = encoding.strip()
+        if not encoding:
+            continue
+        lowered = encoding.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        yield encoding
+    if "utf-8" not in seen:
+        yield "utf-8"
+
+
+def _collect_remote_files(
+    sftp: paramiko.SFTPClient, base_path: str, allowed_exts: Optional[Sequence[str]]
+) -> List[RemoteFile]:
+    allowed = None
+    if allowed_exts:
+        allowed = {
+            ext if ext.startswith(".") else f".{ext}"
+            for ext in (e.lower().strip() for e in allowed_exts)
+            if ext
+        }
+
+    files: List[RemoteFile] = []
+
+    def _walk(current_path: str) -> None:
+        entries: List[SFTPAttributes] = sftp.listdir_attr(current_path)
+        for attr in entries:
+            name = attr.filename
+            if name in (".", ".."):
+                continue
+            full_path = posixpath.join(current_path, name)
+            if stat.S_ISDIR(attr.st_mode):
+                _walk(full_path)
+                continue
+            if allowed and posixpath.splitext(name)[1].lower() not in allowed:
+                continue
+            files.append(
+                RemoteFile(path=full_path, size=attr.st_size, mtime=attr.st_mtime)
+            )
+
+    _walk(base_path)
+    return files
+
+
+def _list_remote_with_fallback(
+    ssh_client: SSHClient, config: SyncConfig
+) -> Tuple[paramiko.SFTPClient, List[RemoteFile], str]:
+    last_exc: Optional[Exception] = None
+    base_path = config.remote_base()
+    for encoding in _iter_encodings(config):
+        logger.info(
+            "Intentando listar archivos usando la codificación '%s'", encoding
+        )
+        sftp = _create_sftp_client(ssh_client, encoding)
+        try:
+            files = _collect_remote_files(
+                sftp, base_path, config.allowed_extensions
+            )
+            logger.info(
+                "Se detectaron %d archivos remotos (codificación '%s')",
+                len(files),
+                encoding,
+            )
+            return sftp, files, encoding
+        except UnicodeDecodeError as exc:
+            logger.warning(
+                "Fallo al decodificar nombres de archivo con la codificación '%s'.",
+                encoding,
+            )
+            last_exc = exc
+            sftp.close()
+        except FileNotFoundError as exc:
+            sftp.close()
+            raise SyncError(
+                f"La ruta remota '{base_path}' no existe o no es accesible"
+            ) from exc
+    if last_exc:
+        raise SyncError(
+            "Ninguna de las codificaciones configuradas permitió listar el servidor"
+        ) from last_exc
+    raise SyncError("No se pudo crear una conexión SFTP válida")
+
+
+def _list_existing_objects(
+    s3_client, bucket: str, prefix: str
+) -> Dict[str, int]:
+    paginator = s3_client.get_paginator("list_objects_v2")
+    kwargs = {"Bucket": bucket}
+    if prefix:
+        kwargs["Prefix"] = prefix
+    existing: Dict[str, int] = {}
+    for page in paginator.paginate(**kwargs):
+        for obj in page.get("Contents", []):
+            existing[obj["Key"]] = obj.get("Size", 0)
+    return existing
+
+
+def _remote_to_s3_key(remote: RemoteFile, base_path: str, prefix: str) -> str:
+    relative = remote.relative_to(base_path)
+    if relative == ".":
+        relative = posixpath.basename(remote.path)
+    key = relative.replace("\\", "/")
+    if prefix:
+        key = f"{prefix}/{key}"
+    return key
+
+
+def run_sync(config: SyncConfig, options: Optional[SyncOptions] = None) -> SyncSummary:
+    options = options or SyncOptions()
+    if not config.sftp_host:
+        raise SyncError("Debe especificarse el host del servidor SFTP")
+    if not config.s3_bucket:
+        raise SyncError("Debe especificarse el bucket de destino en S3")
+
+    logger.debug("Configuración empleada: %s", dataclasses.asdict(config))
+
+    ssh_client = _connect_ssh(config)
+    logger.info("Conexión SSH establecida con %s", config.sftp_host)
+
+    try:
+        sftp, remote_files, encoding = _list_remote_with_fallback(ssh_client, config)
+    except Exception:
+        ssh_client.close()
+        raise
+
+    existing_objects: Dict[str, int] = {}
+    s3_client = None
+    if not options.list_only:
+        try:
+            session_kwargs = {}
+            if config.aws_region:
+                session_kwargs["region_name"] = config.aws_region
+            session = boto3.session.Session(**session_kwargs)
+            s3_client = session.client("s3")
+            existing_objects = _list_existing_objects(
+                s3_client, config.s3_bucket, config.normalized_prefix()
+            )
+            logger.info(
+                "Se detectaron %d archivos existentes en S3 bajo el prefijo '%s'",
+                len(existing_objects),
+                config.normalized_prefix() or "<sin prefijo>",
+            )
+        except (BotoCoreError, ClientError, NoCredentialsError) as exc:
+            sftp.close()
+            ssh_client.close()
+            raise SyncError("No se pudo inicializar el cliente de S3") from exc
+    else:
+        logger.info(
+            "Ejecutando en modo 'solo listar'; no se consultará S3 ni se subirá nada."
+        )
+
+    uploaded = 0
+    skipped = 0
+    deleted = 0
+
+    base_path = config.remote_base()
+    prefix = config.normalized_prefix()
+
+    try:
+        if options.list_only:
+            for remote in remote_files:
+                logger.info("%s (%.2f MB)", remote.path, remote.size / (1024 * 1024))
+        else:
+            assert s3_client is not None
+            for remote in remote_files:
+                key = _remote_to_s3_key(remote, base_path, prefix)
+                if key in existing_objects:
+                    skipped += 1
+                    logger.debug(
+                        "Omitiendo '%s' porque ya existe en S3 con tamaño %d",
+                        key,
+                        existing_objects[key],
+                    )
+                    continue
+                if options.dry_run:
+                    uploaded += 1
+                    logger.info("[DRY-RUN] Se subiría '%s'", key)
+                    continue
+                logger.info("Subiendo '%s' a s3://%s", key, config.s3_bucket)
+                with sftp.file(remote.path, "rb") as remote_fp:
+                    s3_client.upload_fileobj(remote_fp, config.s3_bucket, key)
+                uploaded += 1
+                if config.delete_remote_after_upload:
+                    sftp.remove(remote.path)
+                    deleted += 1
+                    logger.info("Archivo remoto '%s' eliminado tras la carga", remote.path)
+    finally:
+        sftp.close()
+        ssh_client.close()
+
+    return SyncSummary(
+        encoding_used=encoding,
+        total_remote_files=len(remote_files),
+        uploaded_files=uploaded,
+        skipped_existing=skipped,
+        deleted_remote=deleted,
+        dry_run=options.dry_run,
+        list_only=options.list_only,
+    )
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sincroniza archivos desde un servidor SFTP hacia un bucket de S3"
+    )
+    parser.add_argument("--env-file", help="Ruta a un archivo .env con variables")
+    parser.add_argument("--dry-run", action="store_true", help="Simula la carga a S3")
+    parser.add_argument(
+        "--list-only",
+        action="store_true",
+        help="Solo lista los archivos encontrados sin subirlos",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Muestra información detallada"
+    )
+    return parser.parse_args(argv)
+
+
+def _load_env_file(env_file: Optional[str]) -> None:
+    if not env_file:
+        return
+    if load_dotenv is None:
+        raise SyncError(
+            "Se indicó un archivo .env pero python-dotenv no está instalado"
+        )
+    if not load_dotenv(env_file):
+        raise SyncError(f"No se pudo cargar el archivo de entorno '{env_file}'")
+
+
+def config_from_env() -> SyncConfig:
+    def _split(value: Optional[str]) -> Optional[List[str]]:
+        if not value:
+            return None
+        parts = [item.strip() for item in value.split(",")]
+        return [item for item in parts if item]
+
+    return SyncConfig(
+        sftp_host=os.environ.get("SFTP_HOST", ""),
+        sftp_port=int(os.environ.get("SFTP_PORT", "22")),
+        sftp_username=os.environ.get("SFTP_USERNAME", ""),
+        sftp_password=os.environ.get("SFTP_PASSWORD") or None,
+        sftp_private_key=os.environ.get("SFTP_PRIVATE_KEY") or None,
+        sftp_passphrase=os.environ.get("SFTP_PASSPHRASE") or None,
+        sftp_base_path=os.environ.get("SFTP_BASE_PATH", "."),
+        sftp_encodings=_split(os.environ.get("SFTP_ENCODINGS"))
+        or ("utf-8", "latin-1", "cp1252"),
+        s3_bucket=os.environ.get("S3_BUCKET", ""),
+        s3_prefix=os.environ.get("S3_PREFIX", ""),
+        aws_region=os.environ.get("AWS_REGION") or None,
+        delete_remote_after_upload=
+            os.environ.get("DELETE_REMOTE_AFTER_UPLOAD", "false").lower()
+            in {"1", "true", "yes", "on"},
+        allowed_extensions=_split(os.environ.get("ALLOWED_EXTENSIONS")),
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = _parse_args(argv)
+    _setup_logger(args.verbose)
+    _load_env_file(args.env_file)
+
+    config = config_from_env()
+    options = SyncOptions(dry_run=args.dry_run, list_only=args.list_only)
+
+    try:
+        summary = run_sync(config, options)
+    except SyncError as exc:
+        logger.error("%s", exc)
+        raise SystemExit(1) from exc
+
+    logger.info("===== Resumen =====")
+    logger.info("Codificación utilizada: %s", summary.encoding_used)
+    logger.info("Archivos remotos encontrados: %d", summary.total_remote_files)
+    if not summary.list_only:
+        logger.info("Archivos subidos: %d", summary.uploaded_files)
+        logger.info("Archivos omitidos por existir: %d", summary.skipped_existing)
+        if config.delete_remote_after_upload:
+            logger.info("Archivos remotos eliminados: %d", summary.deleted_remote)
+    if summary.dry_run:
+        logger.info("La ejecución fue un simulacro (dry-run)")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sincronizador Orion</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Sincronización de archivos Orion</h1>
+      <p class="intro">
+        Completa los datos de conexión y ejecuta la sincronización directamente desde tu navegador.
+        Las opciones de codificación permiten manejar nombres de archivo con caracteres especiales.
+      </p>
+
+      <form method="post" class="card">
+        <section>
+          <h2>Servidor SFTP</h2>
+          <div class="field">
+            <label for="sftp_host">Host</label>
+            <input type="text" id="sftp_host" name="sftp_host" value="{{ form.sftp_host }}" required>
+          </div>
+          <div class="field grid">
+            <div>
+              <label for="sftp_port">Puerto</label>
+              <input type="number" id="sftp_port" name="sftp_port" value="{{ form.sftp_port }}" min="1" max="65535" required>
+            </div>
+            <div>
+              <label for="sftp_username">Usuario</label>
+              <input type="text" id="sftp_username" name="sftp_username" value="{{ form.sftp_username }}">
+            </div>
+          </div>
+          <div class="field grid">
+            <div>
+              <label for="sftp_password">Contraseña</label>
+              <input type="password" id="sftp_password" name="sftp_password" value="{{ form.sftp_password }}">
+            </div>
+            <div>
+              <label for="sftp_private_key">Clave privada (opcional)</label>
+              <input type="text" id="sftp_private_key" name="sftp_private_key" value="{{ form.sftp_private_key }}" placeholder="/ruta/a/id_rsa">
+            </div>
+          </div>
+          <div class="field">
+            <label for="sftp_passphrase">Passphrase de la clave</label>
+            <input type="password" id="sftp_passphrase" name="sftp_passphrase" value="{{ form.sftp_passphrase }}">
+          </div>
+          <div class="field">
+            <label for="sftp_base_path">Ruta base</label>
+            <input type="text" id="sftp_base_path" name="sftp_base_path" value="{{ form.sftp_base_path }}" required>
+          </div>
+          <div class="field">
+            <label for="sftp_encodings">Codificaciones (orden de prioridad)</label>
+            <input type="text" id="sftp_encodings" name="sftp_encodings" value="{{ form.sftp_encodings }}" placeholder="utf-8, latin-1, cp1252">
+            <p class="hint">Se probarán en el orden indicado hasta que la lista de archivos sea exitosa.</p>
+          </div>
+        </section>
+
+        <section>
+          <h2>Destino en Amazon S3</h2>
+          <div class="field">
+            <label for="s3_bucket">Bucket</label>
+            <input type="text" id="s3_bucket" name="s3_bucket" value="{{ form.s3_bucket }}" required>
+          </div>
+          <div class="field">
+            <label for="s3_prefix">Prefijo (carpeta)</label>
+            <input type="text" id="s3_prefix" name="s3_prefix" value="{{ form.s3_prefix }}" placeholder="videosorion">
+          </div>
+          <div class="field">
+            <label for="aws_region">Región de AWS</label>
+            <input type="text" id="aws_region" name="aws_region" value="{{ form.aws_region }}" placeholder="us-east-1">
+          </div>
+          <div class="field">
+            <label for="allowed_extensions">Extensiones permitidas (opcional)</label>
+            <input type="text" id="allowed_extensions" name="allowed_extensions" value="{{ form.allowed_extensions }}" placeholder="mp4, mov, zip">
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" name="delete_remote_after_upload" value="true" {% if form.delete_remote_after_upload %}checked{% endif %}>
+              Eliminar archivo remoto tras subirlo a S3
+            </label>
+          </div>
+        </section>
+
+        <section>
+          <h2>Opciones de ejecución</h2>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" name="dry_run" value="true" {% if form.dry_run %}checked{% endif %}>
+              Simulación (dry-run)
+            </label>
+          </div>
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" name="list_only" value="true" {% if form.list_only %}checked{% endif %}>
+              Solo listar archivos sin subir
+            </label>
+          </div>
+        </section>
+
+        <div class="actions">
+          <button type="submit">Ejecutar sincronización</button>
+        </div>
+      </form>
+
+      {% if error %}
+      <section class="card error">
+        <h2>Ocurrió un problema</h2>
+        <p>{{ error }}</p>
+      </section>
+      {% endif %}
+
+      {% if summary %}
+      <section class="card">
+        <h2>Resumen de la ejecución</h2>
+        <ul>
+          <li><strong>Codificación utilizada:</strong> {{ summary.encoding_used }}</li>
+          <li><strong>Archivos remotos:</strong> {{ summary.total_remote_files }}</li>
+          {% if not summary.list_only %}
+          <li><strong>Subidos a S3:</strong> {{ summary.uploaded_files }}</li>
+          <li><strong>Omitidos por existir:</strong> {{ summary.skipped_existing }}</li>
+          {% if summary.deleted_remote %}
+          <li><strong>Eliminados en origen:</strong> {{ summary.deleted_remote }}</li>
+          {% endif %}
+          {% endif %}
+          {% if summary.dry_run %}
+          <li><strong>Modo simulación activado.</strong></li>
+          {% endif %}
+        </ul>
+      </section>
+      {% endif %}
+
+      {% if logs %}
+      <section class="card logs">
+        <h2>Registro de la ejecución</h2>
+        <pre>{{ logs }}</pre>
+      </section>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,142 @@
+"""Aplicación web para ejecutar ``sync_orion_files`` desde el navegador."""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from flask import Flask, render_template, request
+
+from sync_orion_files import (
+    SyncConfig,
+    SyncError,
+    SyncOptions,
+    config_from_env,
+    run_sync,
+)
+
+app = Flask(__name__)
+app.config.setdefault("SECRET_KEY", "cambia-esta-clave")
+
+
+class _BufferLogHandler(logging.Handler):
+    """Handler en memoria para capturar logs de la sincronización."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lines: List[str] = []
+        self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - handler
+        try:
+            self._lines.append(self.format(record))
+        except Exception:  # pragma: no cover - no interrumpir la vista
+            pass
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self._lines)
+
+
+def _parse_bool(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _split_csv(value: str) -> List[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    defaults = config_from_env()
+    context = {
+        "form": {
+            "sftp_host": defaults.sftp_host,
+            "sftp_port": defaults.sftp_port,
+            "sftp_username": defaults.sftp_username,
+            "sftp_password": "",
+            "sftp_private_key": defaults.sftp_private_key or "",
+            "sftp_passphrase": "",
+            "sftp_base_path": defaults.sftp_base_path,
+            "sftp_encodings": ", ".join(defaults.sftp_encodings),
+            "s3_bucket": defaults.s3_bucket,
+            "s3_prefix": defaults.s3_prefix,
+            "aws_region": defaults.aws_region or "",
+            "delete_remote_after_upload": defaults.delete_remote_after_upload,
+            "allowed_extensions": ", ".join(defaults.allowed_extensions or []),
+            "dry_run": False,
+            "list_only": False,
+        },
+        "summary": None,
+        "logs": "",
+        "error": None,
+    }
+
+    if request.method == "POST":
+        form = request.form
+        encodings = _split_csv(form.get("sftp_encodings", "utf-8,latin-1,cp1252"))
+        allowed_exts = _split_csv(form.get("allowed_extensions", ""))
+        config = SyncConfig(
+            sftp_host=form.get("sftp_host", "").strip(),
+            sftp_port=int(form.get("sftp_port", defaults.sftp_port) or defaults.sftp_port),
+            sftp_username=form.get("sftp_username", "").strip(),
+            sftp_password=form.get("sftp_password") or None,
+            sftp_private_key=form.get("sftp_private_key") or None,
+            sftp_passphrase=form.get("sftp_passphrase") or None,
+            sftp_base_path=form.get("sftp_base_path", ".").strip() or ".",
+            sftp_encodings=encodings or defaults.sftp_encodings,
+            s3_bucket=form.get("s3_bucket", "").strip(),
+            s3_prefix=form.get("s3_prefix", "").strip(),
+            aws_region=form.get("aws_region") or None,
+            delete_remote_after_upload=_parse_bool(
+                form.get("delete_remote_after_upload")
+            ),
+            allowed_extensions=allowed_exts or None,
+        )
+        options = SyncOptions(
+            dry_run=_parse_bool(form.get("dry_run")),
+            list_only=_parse_bool(form.get("list_only")),
+        )
+
+        handler = _BufferLogHandler()
+        sync_logger = logging.getLogger("sync_orion")
+        previous_level = sync_logger.level
+        sync_logger.setLevel(logging.INFO)
+        sync_logger.addHandler(handler)
+
+        try:
+            summary = run_sync(config, options)
+            context["summary"] = summary
+        except SyncError as exc:
+            context["error"] = str(exc)
+        finally:
+            sync_logger.removeHandler(handler)
+            sync_logger.setLevel(previous_level)
+            context["logs"] = handler.text
+            context["form"].update({
+                "sftp_host": config.sftp_host,
+                "sftp_port": config.sftp_port,
+                "sftp_username": config.sftp_username,
+                "sftp_private_key": config.sftp_private_key or "",
+                "sftp_base_path": config.sftp_base_path,
+                "sftp_encodings": ", ".join(config.sftp_encodings),
+                "s3_bucket": config.s3_bucket,
+                "s3_prefix": config.s3_prefix,
+                "aws_region": config.aws_region or "",
+                "delete_remote_after_upload": config.delete_remote_after_upload,
+                "allowed_extensions": ", ".join(config.allowed_extensions or []),
+                "dry_run": options.dry_run,
+                "list_only": options.list_only,
+            })
+
+    return render_template("index.html", **context)
+
+
+@app.route("/health")
+def healthcheck():
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True, host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- add a configurable SFTP-to-S3 synchronisation script that retries with alternate encodings to avoid UnicodeDecodeError
- include a Flask web interface to trigger the sync from a browser and review logs
- document setup, environment variables and usage; add supporting assets and dependencies

## Testing
- python -m compileall sync_orion_files.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68cc06fb7c28832da9d42c402c138acc