### PR TITLE
Add configuration for custom S3 credentials and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ Variables principales:
 - `S3_BUCKET`: bucket de destino.
 - `S3_PREFIX`: prefijo (carpeta lógica) dentro del bucket.
 - `AWS_REGION`: región de AWS (opcional).
+- `AWS_ACCESS_KEY_ID` (`ACCESS_KEY`): credencial de acceso para S3.
+- `AWS_SECRET_ACCESS_KEY` (`SECRET_KEY`): clave secreta asociada.
+- `S3_ENDPOINT_URL` (`ENDPOINT_URL`): endpoint personalizado para servicios S3 compatibles.
 - `DELETE_REMOTE_AFTER_UPLOAD`: `true/false` para eliminar el archivo remoto tras subirlo.
 - `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `mp4,mov`).
+
+> También puedes usar las variables `BUCKET_NAME` y `DESTINO_DEF` como alias de
+> `S3_BUCKET` y `S3_PREFIX`, respectivamente.
 
 ## Uso por línea de comandos
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,20 @@
             <input type="text" id="aws_region" name="aws_region" value="{{ form.aws_region }}" placeholder="us-east-1">
           </div>
           <div class="field">
+            <label for="s3_endpoint_url">Endpoint personalizado</label>
+            <input type="text" id="s3_endpoint_url" name="s3_endpoint_url" value="{{ form.s3_endpoint_url }}" placeholder="http://dc-s3.justiciasalta.gov.ar">
+            <p class="hint">Úsalo para servicios compatibles con S3 que no sean AWS.</p>
+          </div>
+          <div class="field">
+            <label for="aws_access_key_id">Access Key ID</label>
+            <input type="text" id="aws_access_key_id" name="aws_access_key_id" value="{{ form.aws_access_key_id }}" placeholder="ACCESS_KEY">
+          </div>
+          <div class="field">
+            <label for="aws_secret_access_key">Secret Access Key</label>
+            <input type="password" id="aws_secret_access_key" name="aws_secret_access_key" value="{{ form.aws_secret_access_key }}" placeholder="SECRET_KEY">
+            <p class="hint">Por seguridad no se mostrará al recargar la página.</p>
+          </div>
+          <div class="field">
             <label for="allowed_extensions">Extensiones permitidas (opcional)</label>
             <input type="text" id="allowed_extensions" name="allowed_extensions" value="{{ form.allowed_extensions }}" placeholder="mp4, mov, zip">
           </div>

--- a/webapp.py
+++ b/webapp.py
@@ -63,6 +63,9 @@ def index():
             "s3_bucket": defaults.s3_bucket,
             "s3_prefix": defaults.s3_prefix,
             "aws_region": defaults.aws_region or "",
+            "s3_endpoint_url": defaults.s3_endpoint_url or "",
+            "aws_access_key_id": defaults.aws_access_key_id or "",
+            "aws_secret_access_key": "",
             "delete_remote_after_upload": defaults.delete_remote_after_upload,
             "allowed_extensions": ", ".join(defaults.allowed_extensions or []),
             "dry_run": False,
@@ -89,6 +92,18 @@ def index():
             s3_bucket=form.get("s3_bucket", "").strip(),
             s3_prefix=form.get("s3_prefix", "").strip(),
             aws_region=form.get("aws_region") or None,
+            s3_endpoint_url=(
+                (form.get("s3_endpoint_url") or "").strip()
+                or defaults.s3_endpoint_url
+            ),
+            aws_access_key_id=(
+                (form.get("aws_access_key_id") or "").strip()
+                or defaults.aws_access_key_id
+            ),
+            aws_secret_access_key=(
+                (form.get("aws_secret_access_key") or "").strip()
+                or defaults.aws_secret_access_key
+            ),
             delete_remote_after_upload=_parse_bool(
                 form.get("delete_remote_after_upload")
             ),
@@ -124,6 +139,9 @@ def index():
                 "s3_bucket": config.s3_bucket,
                 "s3_prefix": config.s3_prefix,
                 "aws_region": config.aws_region or "",
+                "s3_endpoint_url": config.s3_endpoint_url or "",
+                "aws_access_key_id": config.aws_access_key_id or "",
+                "aws_secret_access_key": "",
                 "delete_remote_after_upload": config.delete_remote_after_upload,
                 "allowed_extensions": ", ".join(config.allowed_extensions or []),
                 "dry_run": options.dry_run,


### PR DESCRIPTION
## Summary
- allow configuring S3 access credentials and a custom endpoint for the sync CLI and loader
- expose the new S3 options in the web interface while keeping secrets masked in logs
- document the new environment variables and supported aliases in the README

## Testing
- python -m compileall sync_orion_files.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68cc2aa3b5c4832d8b87be48451b24f4