### PR TITLE
Filtrar archivos webm y robustecer fallback de codificación

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Variables principales:
 - `S3_PREFIX`: prefijo (carpeta lógica) dentro del bucket.
 - `AWS_REGION`: región de AWS (opcional).
 - `DELETE_REMOTE_AFTER_UPLOAD`: `true/false` para eliminar el archivo remoto tras subirlo.
-- `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `mp4,mov`).
+- `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `webm` o `mp4,mov`). Por defecto solo se procesan archivos `.webm`. Usa `*` para aceptar cualquier extensión.
 
 ## Uso por línea de comandos
 


### PR DESCRIPTION
## Summary
- limitar la sincronización a archivos con extensión `.webm` por defecto manteniendo la opción de aceptar todas las extensiones con `*`
- ajustar la interfaz web para reflejar el nuevo comportamiento por defecto y permitir desactivar el filtro explícitamente
- hacer más robusto el fallback de codificación capturando cualquier `UnicodeError`

## Testing
- python -m compileall sync_orion_files.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3bdb2444832dbdcbad59d84d98cc