### PR TITLE
Remove date and prefix filters when collecting files

### DIFF
--- a/sync_orion_files.py
+++ b/sync_orion_files.py
@@ -328,9 +328,6 @@ def _collect_remote_files(
 
     files: List[RemoteFile] = []
 
-    today = datetime.now().date()
-    required_prefix = "38332"
-
     def _walk(current_path: str) -> None:
         try:
             entries = sftp.listdir_attr(current_path)
@@ -349,11 +346,6 @@ def _collect_remote_files(
                 _walk(full_path)
                 continue
             if allowed and posixpath.splitext(name)[1].lower() not in allowed:
-                continue
-            if not name.startswith(required_prefix):
-                continue
-            modified_date = datetime.fromtimestamp(attr.st_mtime).date()
-            if modified_date != today:
                 continue
             files.append(
                 RemoteFile(path=full_path, size=attr.st_size, mtime=attr.st_mtime)


### PR DESCRIPTION
## Summary
- allow `_collect_remote_files` to return every file that matches the allowed extensions by removing the enforced prefix and same-day filters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc89979a64832d83715178d90d356d