### PR TITLE
Agregar selección de archivos y progreso en la interfaz web

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -96,7 +96,11 @@ h1 {
 }
 
 .actions {
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
 }
 
 .actions button {
@@ -107,11 +111,181 @@ h1 {
   font-size: 1rem;
   border-radius: 8px;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .actions button:hover {
   background: #0053a4;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+button.secondary:hover,
+button.secondary:focus {
+  background: rgba(0, 106, 212, 0.1);
+  color: var(--accent);
+}
+
+button.secondary:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 106, 212, 0.15);
+}
+
+.transfer-plan {
+  margin-top: 2rem;
+}
+
+.selection-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.selection-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.selection-buttons button {
+  padding: 0.55rem 1.1rem;
+}
+
+.selection-count {
+  font-weight: 500;
+}
+
+.file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #cbd2d9;
+  border-radius: 10px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.file-list li {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e4e7eb;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.file-list li:last-child {
+  border-bottom: none;
+}
+
+.file-option {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.file-option input[type="checkbox"] {
+  margin-top: 0.25rem;
+}
+
+.file-name {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.file-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.file-list.selectable li {
+  flex-direction: column;
+  padding: 0;
+}
+
+.file-list.selectable label {
+  padding: 0.75rem 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.file-list.selectable label:hover {
+  background: rgba(0, 106, 212, 0.08);
+}
+
+.file-list.existing li {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.existing-files {
+  margin-top: 1.5rem;
+}
+
+.total-size {
+  margin-top: 0.75rem;
+}
+
+.progress-card {
+  margin-top: 1.5rem;
+}
+
+.progress-overall {
+  margin-bottom: 1.25rem;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.progress-bar {
+  background: #e4e7eb;
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+  margin-top: 0.4rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.progress-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.progress-list .file-name {
+  font-weight: 600;
+}
+
+.progress-list .percentage {
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .card.error {

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,8 +98,70 @@
           </div>
         </section>
 
+        {% if plan %}
+        <section class="transfer-plan" data-total-missing="{{ plan.total_missing_bytes }}">
+          <h2>Archivos detectados en el origen</h2>
+          <p class="hint">
+            Codificación utilizada: <strong>{{ plan.encoding }}</strong>. Se encontraron
+            <strong>{{ plan.remote_total }}</strong> archivos y
+            <strong>{{ plan.existing_count }}</strong> ya existen en el destino.
+          </p>
+          {% if plan.missing_files %}
+          <div class="selection-actions">
+            <div class="selection-buttons">
+              <button type="button" class="secondary outline" data-action="select-all">Seleccionar todos</button>
+              <button type="button" class="secondary outline" data-action="select-none">Deseleccionar todos</button>
+            </div>
+            <div class="selection-count">
+              Seleccionados <strong data-selected-count>{{ selected_files|length }}</strong>
+              de {{ plan.missing_count }} pendientes.
+            </div>
+          </div>
+          <ul class="file-list selectable">
+            {% for item in plan.missing_files %}
+            <li>
+              <label class="file-option">
+                <input type="checkbox" name="selected_files" value="{{ item.remote_path }}" data-size="{{ item.size }}" {% if item.remote_path in selected_files %}checked{% endif %}>
+                <span class="file-name">{{ item.remote_path }}</span>
+                <span class="file-meta">{{ item.s3_key }} · {{ item.size_label }}</span>
+              </label>
+            </li>
+            {% endfor %}
+          </ul>
+          <p class="hint total-size">
+            Tamaño seleccionado: <strong data-selected-size>{{ plan.selected_total_label }}</strong>
+            de {{ plan.total_missing_label }} disponibles.
+          </p>
+          {% else %}
+          <p class="hint">
+            No hay archivos pendientes de copiar: todos los archivos remotos ya están en el destino.
+          </p>
+          {% endif %}
+        </section>
+        <section class="existing-files">
+          <h2>Archivos existentes en S3</h2>
+          {% if plan.existing_files %}
+          <ul class="file-list existing">
+            {% for item in plan.existing_files %}
+            <li>
+              <span class="file-name">{{ item.key }}</span>
+              <span class="file-meta">{{ item.size_label }}</span>
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <p class="hint">No se encontraron archivos en el destino con el prefijo indicado.</p>
+          {% endif %}
+        </section>
+        {% endif %}
+
         <div class="actions">
-          <button type="submit">Ejecutar sincronización</button>
+          <button type="submit" name="operation" value="list" class="secondary">
+            {% if plan %}Actualizar listado{% else %}Listar archivos disponibles{% endif %}
+          </button>
+          {% if plan and plan.missing_count %}
+          <button type="submit" name="operation" value="sync">Copiar seleccionados</button>
+          {% endif %}
         </div>
       </form>
 
@@ -116,9 +178,11 @@
         <ul>
           <li><strong>Codificación utilizada:</strong> {{ summary.encoding_used }}</li>
           <li><strong>Archivos remotos:</strong> {{ summary.total_remote_files }}</li>
+          <li><strong>Archivos seleccionados:</strong> {{ summary.selected_files }}</li>
           {% if not summary.list_only %}
           <li><strong>Subidos a S3:</strong> {{ summary.uploaded_files }}</li>
           <li><strong>Omitidos por existir:</strong> {{ summary.skipped_existing }}</li>
+          <li><strong>Tamaño transferido:</strong> {{ summary.total_transferred|human_size }} / {{ summary.total_bytes|human_size }}</li>
           {% if summary.deleted_remote %}
           <li><strong>Eliminados en origen:</strong> {{ summary.deleted_remote }}</li>
           {% endif %}
@@ -130,6 +194,40 @@
       </section>
       {% endif %}
 
+      {% if summary %}
+      <section class="card progress-card">
+        <h2>Avance de la copia</h2>
+        <div class="progress-overall">
+          <div class="progress-header">
+            <span>Total transferido</span>
+            <span>{{ '%.1f' % summary.total_percentage }}%</span>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-fill" style="width: {{ summary.total_percentage }}%"></div>
+          </div>
+          <p class="progress-meta">{{ summary.total_transferred|human_size }} de {{ summary.total_bytes|human_size }}</p>
+        </div>
+        {% if summary.progress %}
+        <ul class="progress-list">
+          {% for item in summary.progress %}
+          <li>
+            <div class="progress-header">
+              <span class="file-name">{{ item.s3_key }}</span>
+              <span class="percentage">{{ '%.1f' % item.percentage }}%</span>
+            </div>
+            <div class="progress-bar">
+              <div class="progress-fill" style="width: {{ item.percentage }}%"></div>
+            </div>
+            <p class="progress-meta">{{ item.transferred|human_size }} de {{ item.size|human_size }}</p>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="hint">No hubo archivos para copiar en esta ejecución.</p>
+        {% endif %}
+      </section>
+      {% endif %}
+
       {% if logs %}
       <section class="card logs">
         <h2>Registro de la ejecución</h2>
@@ -137,5 +235,72 @@
       </section>
       {% endif %}
     </main>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const planSection = document.querySelector('.transfer-plan');
+        if (!planSection) {
+          return;
+        }
+        const checkboxes = Array.from(planSection.querySelectorAll('input[name="selected_files"]'));
+        const selectAllBtn = planSection.querySelector('[data-action="select-all"]');
+        const selectNoneBtn = planSection.querySelector('[data-action="select-none"]');
+        const countEl = planSection.querySelector('[data-selected-count]');
+        const sizeEl = planSection.querySelector('[data-selected-size]');
+
+        const formatSize = (bytes) => {
+          const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+          let size = bytes;
+          for (const unit of units) {
+            if (size < 1024 || unit === units[units.length - 1]) {
+              if (unit === 'B') {
+                return `${Math.round(size)} ${unit}`;
+              }
+              return `${size.toFixed(2)} ${unit}`;
+            }
+            size /= 1024;
+          }
+          return `${size.toFixed(2)} PB`;
+        };
+
+        const updateSelection = () => {
+          let total = 0;
+          let count = 0;
+          for (const checkbox of checkboxes) {
+            if (checkbox.checked) {
+              count += 1;
+              total += Number(checkbox.dataset.size || '0');
+            }
+          }
+          if (countEl) {
+            countEl.textContent = count;
+          }
+          if (sizeEl) {
+            sizeEl.textContent = formatSize(total);
+          }
+        };
+
+        selectAllBtn?.addEventListener('click', (event) => {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => {
+            checkbox.checked = true;
+          });
+          updateSelection();
+        });
+
+        selectNoneBtn?.addEventListener('click', (event) => {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => {
+            checkbox.checked = false;
+          });
+          updateSelection();
+        });
+
+        checkboxes.forEach((checkbox) => {
+          checkbox.addEventListener('change', updateSelection);
+        });
+
+        updateSelection();
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- generar planes de transferencia reutilizables y permitir que la sincronización cargue solo los archivos seleccionados
- capturar el avance de cada carga y el total transferido para exponerlo en la interfaz y en los resúmenes
- actualizar la interfaz web con listas seleccionables, listado de archivos existentes, barra de progreso y mejoras de estilo

## Testing
- python -m compileall webapp.py sync_orion_files.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8f76ec1c832dbdf1e24652145ed7