### PR TITLE
Mantener credenciales SFTP en la interfaz web

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -273,6 +273,8 @@ def index():
                 "sftp_port": config.sftp_port,
                 "sftp_username": config.sftp_username,
                 "sftp_private_key": config.sftp_private_key or "",
+                "sftp_password": password_raw,
+                "sftp_passphrase": passphrase_raw,
                 "sftp_base_path": config.sftp_base_path,
                 "sftp_encodings": ", ".join(config.sftp_encodings),
                 "s3_bucket": config.s3_bucket,


### PR DESCRIPTION
## Summary
- conservar los valores de contraseña y passphrase enviados en el formulario
- volver a rellenar estos campos al renderizar la página para que puedan reutilizarse en una nueva acción

## Testing
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3f7d2710832d93a00af96ae0bf51