### PR TITLE
Ensure selected files from UI are preserved on sync

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -100,6 +100,7 @@
 
         {% if plan %}
         <section class="transfer-plan" data-total-missing="{{ plan.total_missing_bytes }}">
+          <input type="hidden" name="selected_files_payload" value='{{ selected_files|tojson }}'>
           <h2>Archivos detectados en el origen</h2>
           <p class="hint">
             Codificación utilizada: <strong>{{ plan.encoding }}</strong>. Se encontraron
@@ -246,6 +247,7 @@
         const selectNoneBtn = planSection.querySelector('[data-action="select-none"]');
         const countEl = planSection.querySelector('[data-selected-count]');
         const sizeEl = planSection.querySelector('[data-selected-size]');
+        const payloadInput = planSection.querySelector('input[name="selected_files_payload"]');
 
         const formatSize = (bytes) => {
           const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
@@ -265,10 +267,12 @@
         const updateSelection = () => {
           let total = 0;
           let count = 0;
+          const selectedValues = [];
           for (const checkbox of checkboxes) {
             if (checkbox.checked) {
               count += 1;
               total += Number(checkbox.dataset.size || '0');
+              selectedValues.push(checkbox.value);
             }
           }
           if (countEl) {
@@ -276,6 +280,9 @@
           }
           if (sizeEl) {
             sizeEl.textContent = formatSize(total);
+          }
+          if (payloadInput) {
+            payloadInput.value = JSON.stringify(selectedValues);
           }
         };
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,6 +1,7 @@
 """Aplicación web para ejecutar ``sync_orion_files`` desde el navegador."""
 from __future__ import annotations
 
+import json
 import logging
 import posixpath
 import traceback
@@ -50,6 +51,18 @@ def _parse_bool(value: Optional[str]) -> bool:
 
 def _split_csv(value: str) -> List[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _parse_selection_payload(raw: str) -> List[str]:
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, str) and item]
 
 
 def _format_size(num_bytes: int) -> str:
@@ -239,6 +252,9 @@ def index():
 
         operation = form.get("operation", "list")
         selected_files = list(form.getlist("selected_files"))
+        if not selected_files:
+            payload_raw = form.get("selected_files_payload", "")
+            selected_files = _parse_selection_payload(payload_raw)
         context["selected_files"] = selected_files
         context["form"]["operation"] = operation
 


### PR DESCRIPTION
## Summary
- add a JSON payload helper in the Flask view to recover selected files when the browser omits checkbox data
- store the current selection in a hidden input that the frontend keeps in sync so the server can always read it
- update the selection script to mirror checked files into the hidden payload while keeping the counters updated

## Testing
- python -m compileall sync_orion_files.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68cd4cd3f8fc832dbdf664621b9d5080