### PR TITLE
Add include option placeholder page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -315,3 +315,23 @@ button:disabled:hover {
   outline: none;
   box-shadow: 0 0 0 3px rgba(0, 106, 212, 0.15);
 }
+
+.success-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2f9e44;
+  color: #fff;
+  padding: 0.95rem 1.6rem;
+  border-radius: 10px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.success-link:hover,
+.success-link:focus {
+  background: #237a36;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(47, 158, 68, 0.2);
+}

--- a/templates/incluir.html
+++ b/templates/incluir.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Incluir en base gestor</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <main class="container menu-container">
+      <section class="card menu-card">
+        <h1>Incluir en base gestor</h1>
+        <p class="intro">En construccion</p>
+        <a href="{{ url_for('menu') }}" class="secondary">Volver al inicio</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -19,6 +19,9 @@
           <li>
             <a href="{{ url_for('copy_view') }}" class="primary-link">Copiar Archivos desde NAS a S3</a>
           </li>
+          <li>
+            <a href="{{ url_for('include_view') }}" class="success-link">incluir en base gestor</a>
+          </li>
         </ul>
       </section>
     </main>

--- a/webapp.py
+++ b/webapp.py
@@ -320,6 +320,11 @@ def menu():
     return render_template("menu.html")
 
 
+@app.route("/incluir")
+def include_view():
+    return render_template("incluir.html")
+
+
 @app.route("/copy", methods=["GET", "POST"])
 def copy_view():
     defaults = config_from_env()


### PR DESCRIPTION
## Summary
- add a new "incluir en base gestor" entry on the home menu with green styling
- create a placeholder route and template that shows the feature is under construction

## Testing
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d287bda998832d8fbbc866b866cdf2