### PR TITLE
Show database connection status on include page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3>=1.28,<2.0
 paramiko>=3.3,<4.0
 python-dotenv>=1.0,<2.0
 Flask>=3.0,<4.0
+psycopg2-binary>=2.9,<3.0

--- a/templates/incluir.html
+++ b/templates/incluir.html
@@ -10,7 +10,16 @@
     <main class="container menu-container">
       <section class="card menu-card">
         <h1>Incluir en base gestor</h1>
-        <p class="intro">En construccion</p>
+        {% if connection_status %}
+        <div class="status-banner">Conectado a la base de datos PostgreSQL.</div>
+        {% else %}
+        <div class="status-banner error">
+          No se pudo establecer la conexión con la base de datos.
+          {% if error_message %}
+          <div class="intro">{{ error_message }}</div>
+          {% endif %}
+        </div>
+        {% endif %}
         <a href="{{ url_for('menu') }}" class="secondary">Volver al inicio</a>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add psycopg2 dependency and connect to the PostgreSQL instance when rendering the include view
- surface the connection status and any error message on incluir.html

## Testing
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a338ca9c832d9f2bcaa40263f1b7