### PR TITLE
Add database inclusion workflow for gestor base

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -198,6 +198,60 @@ button:disabled:hover {
   margin-top: 2rem;
 }
 
+.include-card .intro {
+  margin-top: 0.5rem;
+}
+
+.include-hint {
+  margin-top: 0.5rem;
+}
+
+.include-actions {
+  margin-top: 1rem;
+}
+
+.include-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.result-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.count-badge {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.file-list.compact li {
+  padding: 0.6rem 0.85rem;
+}
+
+.empty-state {
+  border: 1px dashed #cbd2d9;
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  color: var(--muted);
+  background: #f5f7fa;
+}
+
 .file-list {
   list-style: none;
   margin: 0;

--- a/templates/incluir.html
+++ b/templates/incluir.html
@@ -7,9 +7,13 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   </head>
   <body>
-    <main class="container menu-container">
-      <section class="card menu-card">
+    <main class="container">
+      <header class="page-header">
         <h1>Incluir en base gestor</h1>
+        <a href="{{ url_for('menu') }}" class="secondary back-button">Volver al inicio</a>
+      </header>
+
+      <section class="card include-card">
         {% if connection_status %}
         <div class="status-banner">Conectado a la base de datos PostgreSQL.</div>
         {% else %}
@@ -20,7 +24,72 @@
           {% endif %}
         </div>
         {% endif %}
-        <a href="{{ url_for('menu') }}" class="secondary">Volver al inicio</a>
+
+        <p class="intro">
+          Utilizá este asistente para incorporar a la base gestor los archivos detectados en
+          el almacenamiento S3. Se listarán los elementos que ya estaban registrados y los que se
+          agreguen durante la operación actual.
+        </p>
+
+        {% if s3_bucket %}
+        <p class="hint include-hint">
+          Bucket configurado: <strong>{{ s3_bucket }}</strong>
+          {% if s3_prefix %}
+          · Prefijo: <strong>{{ s3_prefix }}</strong>
+          {% else %}
+          · Prefijo: <strong>sin prefijo</strong>
+          {% endif %}
+        </p>
+        {% endif %}
+
+        <form method="post" class="include-actions">
+          <div class="actions">
+            <button type="submit" name="operation" value="incorporate" {% if not connection_status %}disabled{% endif %}>
+              Incorporar a la base
+            </button>
+          </div>
+        </form>
+
+        {% if operation_message %}
+        <div class="status-banner">{{ operation_message }}</div>
+        {% endif %}
+        {% if operation_error %}
+        <div class="status-banner error">{{ operation_error }}</div>
+        {% endif %}
+
+        <div class="include-results">
+          <section class="result-panel">
+            <div class="panel-header">
+              <h2>Archivos ya registrados</h2>
+              <span class="count-badge">{{ existing_matches|length }}</span>
+            </div>
+            {% if existing_matches %}
+            <ul class="file-list compact">
+              {% for item in existing_matches %}
+              <li><span class="file-name">{{ item }}</span></li>
+              {% endfor %}
+            </ul>
+            {% else %}
+            <div class="empty-state">Aún no se registraron archivos para este origen.</div>
+            {% endif %}
+          </section>
+
+          <section class="result-panel">
+            <div class="panel-header">
+              <h2>Agregados en esta ejecución</h2>
+              <span class="count-badge">{{ added_records|length }}</span>
+            </div>
+            {% if added_records %}
+            <ul class="file-list compact">
+              {% for item in added_records %}
+              <li><span class="file-name">{{ item }}</span></li>
+              {% endfor %}
+            </ul>
+            {% else %}
+            <div class="empty-state">Aún no se incorporaron archivos en esta sesión.</div>
+            {% endif %}
+          </section>
+        </div>
       </section>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- connect the "Incluir en base gestor" view with PostgreSQL and S3 to classify and add files
- expose configurable helpers to fetch existing records, list S3 objects, and insert new entries safely
- redesign the include template with an action button, status messaging, and panels showing existing and newly added files, plus related styles

## Testing
- python -m compileall sync_orion_files.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b5bf3af8832da9ae0817dcb02530