### PR TITLE
Corrige nombre de base de datos por defecto a gestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ python register_s3_documents.py --env-file .env --verbose
 El script crea una URL firmada con vigencia de 7 días y completa los campos
 indicados en `sgdpjs`. Usa las variables de entorno estándar (`PGHOST`,
 `PGUSER`, etc.) para conectarse a la base de datos; si no están presentes,
-aplicará los valores por defecto utilizados por la aplicación web.
+aplicará los valores por defecto utilizados por la aplicación web, incluida
+la base `gestor`.
 
 ## Interfaz web
 

--- a/register_s3_documents.py
+++ b/register_s3_documents.py
@@ -60,7 +60,7 @@ class DatabaseConfig:
         dbname = (
             os.environ.get("PGDATABASE")
             or os.environ.get("DB_NAME")
-            or "sgdpjs"
+            or "gestor"
         )
         user = os.environ.get("PGUSER") or os.environ.get("DB_USER") or "usrgestor"
         password = (

--- a/webapp.py
+++ b/webapp.py
@@ -359,7 +359,7 @@ def include_view():
     else:
         try:
             connection = psycopg2.connect(
-                dbname="sgdpjs",
+                dbname="gestor",
                 user="usrgestor",
                 password="Gestor97",
                 host="10.18.250.250",


### PR DESCRIPTION
## Summary
- Actualiza la conexión desde la interfaz web para apuntar a la base gestor
- Ajusta la configuración por defecto del script de registro a la base gestor
- Aclara en la documentación que los valores por defecto utilizan la base gestor

## Testing
- python -m compileall sync_orion_files.py webapp.py register_s3_documents.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be2465e0832dba2c946fa8db54b7