### PR TITLE
Ensure inserted GUIDs match GeneXus format

### DIFF
--- a/genexus_utils.py
+++ b/genexus_utils.py
@@ -1,0 +1,16 @@
+"""Utilidades relacionadas con integraciones de GeneXus."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def generate_genexus_guid() -> str:
+    """Genera un GUID con el formato habitual de GeneXus.
+
+    GeneXus almacena los atributos de tipo GUID como cadenas en mayúsculas con
+    guiones. El generador estándar de Python produce letras minúsculas, por lo
+    que aquí se normaliza la representación.
+    """
+
+    return str(uuid.uuid4()).upper()

--- a/register_s3_documents.py
+++ b/register_s3_documents.py
@@ -7,7 +7,6 @@ import argparse
 import logging
 import os
 import posixpath
-import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
@@ -24,6 +23,7 @@ except ImportError:  # pragma: no cover - ``python-dotenv`` es opcional.
     load_dotenv = None
 
 from sync_orion_files import S3_ENDPOINT_URL, SyncConfig, config_from_env
+from genexus_utils import generate_genexus_guid
 
 
 logger = logging.getLogger("register_s3_documents")
@@ -222,7 +222,7 @@ def register_documents(
                 timestamp = _ensure_utc(obj.get("LastModified"))
                 url = _generate_presigned_url(client, config, str(key), expires_in)
 
-                doc_id = str(uuid.uuid4())
+                doc_id = generate_genexus_guid()
                 physical_location = f"s3://{config.s3_bucket}/{key}"
 
                 logger.debug(

--- a/webapp.py
+++ b/webapp.py
@@ -7,7 +7,6 @@ import os
 import posixpath
 import threading
 import traceback
-import uuid
 from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -44,6 +43,7 @@ from sync_orion_files import (
     config_from_env,
     run_sync,
 )
+from genexus_utils import generate_genexus_guid
 
 app = Flask(__name__)
 app.config.setdefault("SECRET_KEY", "cambia-esta-clave")
@@ -647,7 +647,7 @@ def _normalize_object_for_table(
     for column in columns:
         lower = column.lower()
         if lower == "sgddocid":
-            values.append(str(uuid.uuid4()))
+            values.append(generate_genexus_guid())
         elif lower == "sgddocnombre":
             values.append(name)
         elif lower == "sgddoctipo":


### PR DESCRIPTION
## Summary
- add a shared helper that emits GUIDs using the GeneXus uppercase format
- reuse the helper when inserting new records from the web UI and the S3 registration script

## Testing
- python -m compileall sync_orion_files.py webapp.py register_s3_documents.py genexus_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c7b6444c832d95b27032a2083497