### PR TITLE
Evitar inserciones sin sgddocid en sgdpjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Variables principales:
 - `AWS_REGION`: región de AWS (opcional).
 - `DELETE_REMOTE_AFTER_UPLOAD`: `true/false` para eliminar el archivo remoto tras subirlo.
 - `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `webm` o `mp4,mov`). Por defecto solo se procesan archivos `.webm`. Usa `*` para aceptar cualquier extensión.
+- `GESTOR_TABLE` y `GESTOR_SCHEMA`: identifican la tabla y esquema donde se registrarán los archivos (por defecto `public.sgdpjs`).
+- `GESTOR_COLUMNS`: lista separada por comas con las columnas de la tabla destino. Si no se define se utilizarán automáticamente `sgddocid, sgddocnombre, sgddoctipo, sgddotamano, sgddocfecalta, sgddocubfisica, sgddocurl, sgddocusuarioalta, sgddocpublico, sgddocapporigen`. La columna `sgddocid` es obligatoria para generar el identificador GUID requerido por GeneXus.
 
 ## Uso por línea de comandos
 

--- a/webapp.py
+++ b/webapp.py
@@ -45,6 +45,19 @@ from sync_orion_files import (
 )
 from genexus_utils import generate_genexus_guid
 
+DEFAULT_GESTOR_COLUMNS: Tuple[str, ...] = (
+    "sgddocid",
+    "sgddocnombre",
+    "sgddoctipo",
+    "sgddotamano",
+    "sgddocfecalta",
+    "sgddocubfisica",
+    "sgddocurl",
+    "sgddocusuarioalta",
+    "sgddocpublico",
+    "sgddocapporigen",
+)
+
 app = Flask(__name__)
 app.config.setdefault("SECRET_KEY", "cambia-esta-clave")
 
@@ -446,7 +459,7 @@ def _gestor_table_identifiers() -> Tuple[str, str, Tuple[str, ...]]:
         if legacy_column:
             column_names = [col.strip() for col in legacy_column.split(",") if col.strip()]
         else:
-            column_names = ["sgddocnombre", "sgddoctipo"]
+            column_names = list(DEFAULT_GESTOR_COLUMNS)
 
     if not column_names:
         raise RuntimeError(
@@ -460,6 +473,13 @@ def _gestor_table_identifiers() -> Tuple[str, str, Tuple[str, ...]]:
     else:
         schema = "public"
         table_name = table_path
+
+    normalized_columns = {col.lower() for col in column_names}
+    if table_name.lower() == "sgdpjs" and "sgddocid" not in normalized_columns:
+        raise RuntimeError(
+            "La tabla 'sgdpjs' requiere la columna 'sgddocid'. "
+            "Incluya 'sgddocid' en la variable GESTOR_COLUMNS para generar los identificadores."
+        )
 
     return schema, table_name, tuple(column_names)
 


### PR DESCRIPTION
## Summary
- use a default column list that includes sgddocid and associated metadata when inserting into sgdpjs
- raise an explicit configuration error if sgddocid is omitted for sgdpjs so GUIDs are generated before inserting
- document the new defaults and requirements for gestor table configuration variables

## Testing
- python -m compileall sync_orion_files.py webapp.py register_s3_documents.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cc0fc70c832db790483029baad5d