### PR TITLE
Corrige nombre de columna sgddocubicfisica

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Variables principales:
 - `DELETE_REMOTE_AFTER_UPLOAD`: `true/false` para eliminar el archivo remoto tras subirlo.
 - `ALLOWED_EXTENSIONS`: lista separada por comas con extensiones permitidas (por ejemplo `webm` o `mp4,mov`). Por defecto solo se procesan archivos `.webm`. Usa `*` para aceptar cualquier extensión.
 - `GESTOR_TABLE` y `GESTOR_SCHEMA`: identifican la tabla y esquema donde se registrarán los archivos (por defecto `public.sgdpjs`).
-- `GESTOR_COLUMNS`: lista separada por comas con las columnas de la tabla destino. Si no se define se utilizarán automáticamente `sgddocid, sgddocnombre, sgddoctipo, sgddoctamano, sgddocfecalta, sgddocubfisica, sgddocurl, sgddocusuarioalta, sgddocpublico, sgddocapporigen`. La columna `sgddocid` es obligatoria para generar el identificador GUID requerido por GeneXus.
+- `GESTOR_COLUMNS`: lista separada por comas con las columnas de la tabla destino. Si no se define se utilizarán automáticamente `sgddocid, sgddocnombre, sgddoctipo, sgddoctamano, sgddocfecalta, sgddocubicfisica, sgddocurl, sgddocusuarioalta, sgddocpublico, sgddocapporigen`. La columna `sgddocid` es obligatoria para generar el identificador GUID requerido por GeneXus.
 
 ## Uso por línea de comandos
 

--- a/register_s3_documents.py
+++ b/register_s3_documents.py
@@ -243,7 +243,7 @@ def register_documents(
                             sgddoctipo,
                             sgddoctamano,
                             sgddocfecalta,
-                            sgddocubfisica,
+                            sgddocubicfisica,
                             sgddocurl,
                             sgddocusuarioalta,
                             sgddocpublico,

--- a/webapp.py
+++ b/webapp.py
@@ -51,7 +51,7 @@ DEFAULT_GESTOR_COLUMNS: Tuple[str, ...] = (
     "sgddoctipo",
     "sgddoctamano",
     "sgddocfecalta",
-    "sgddocubfisica",
+    "sgddocubicfisica",
     "sgddocurl",
     "sgddocusuarioalta",
     "sgddocpublico",
@@ -676,7 +676,7 @@ def _normalize_object_for_table(
             values.append(size_value)
         elif lower == "sgddocfecalta":
             values.append(timestamp)
-        elif lower == "sgddocubfisica":
+        elif lower in {"sgddocubfisica", "sgddocubicfisica"}:
             values.append(physical_location)
         elif lower == "sgddocurl":
             values.append(url)


### PR DESCRIPTION
## Summary
- actualiza los scripts para usar la columna sgddocubicfisica al registrar documentos
- ajusta el mapeo de columnas por defecto y la documentación para reflejar el nombre correcto
- mantiene compatibilidad aceptando el alias anterior al preparar registros

## Testing
- python -m compileall sync_orion_files.py webapp.py register_s3_documents.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cff548d8832da42a76f6e1fe079c