### PR TITLE
Ensure original document name column is populated

### DIFF
--- a/register_s3_documents.py
+++ b/register_s3_documents.py
@@ -240,6 +240,7 @@ def register_documents(
                         INSERT INTO sgdpjs (
                             sgddocid,
                             sgddocnombre,
+                            sgddocnombreoriginal,
                             sgddoctipo,
                             sgddoctamano,
                             sgddocfecalta,
@@ -249,10 +250,11 @@ def register_documents(
                             sgddocpublico,
                             sgddocapporigen
                         )
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         """,
                         (
                             doc_id,
+                            name,
                             name,
                             extension,
                             size,


### PR DESCRIPTION
## Summary
- include sgddocnombreoriginal in INSERTs when registering S3 files
- populate sgddocnombreoriginal with the same value used for sgddocnombre

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2d240fa64832d9acab2c63ca77f19