### PR TITLE
Populate sgddocnombreoriginal with the original filename

### DIFF
--- a/register_s3_documents.py
+++ b/register_s3_documents.py
@@ -207,6 +207,10 @@ def register_documents(
 
             for obj in _iter_s3_objects(config, client):
                 key = obj.get("Key")
+                original_filename = posixpath.basename(str(key)) if key else ""
+                if not original_filename:
+                    continue
+
                 normalized = _normalize_name_and_extension(str(key))
                 if not normalized:
                     continue
@@ -255,7 +259,7 @@ def register_documents(
                         (
                             doc_id,
                             name,
-                            "original",
+                            original_filename,
                             extension,
                             size,
                             timestamp,


### PR DESCRIPTION
## Summary
- derive the original filename from each S3 object key before inserting records
- store that original name in sgddocnombreoriginal while keeping the existing normalized name and metadata
- skip objects that do not yield a valid filename to avoid constraint violations

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2dc935dc0832dbb5bc07e814118a2