### PR TITLE
Handle original filename when normalizing table rows

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -670,6 +670,8 @@ def _normalize_object_for_table(
             values.append(generate_genexus_guid())
         elif lower == "sgddocnombre":
             values.append(name)
+        elif lower == "sgddocnombreoriginal":
+            values.append(filename)
         elif lower == "sgddoctipo":
             values.append(cleaned_extension)
         elif lower == "sgddotamano":


### PR DESCRIPTION
## Summary
- add support for filling the sgddocnombreoriginal column with the original filename when normalizing S3 objects

## Testing
- python -m compileall sync_orion_files.py webapp.py register_s3_documents.py

------
https://chatgpt.com/codex/tasks/task_e_68d308d85098832d8997a525d611ed87