### PR TITLE
Adjust original name mapping to use normalized name

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -671,7 +671,7 @@ def _normalize_object_for_table(
         elif lower == "sgddocnombre":
             values.append(name)
         elif lower == "sgddocnombreoriginal":
-            values.append(filename)
+            values.append(name)
         elif lower == "sgddoctipo":
             values.append(cleaned_extension)
         elif lower == "sgddotamano":


### PR DESCRIPTION
## Summary
- update the `sgddocnombreoriginal` field population to reuse the normalized file name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d30be0371c832dbeba1fe690380916