### PR TITLE
Add build timestamp banner and expose insert SQL on errors

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -40,6 +40,12 @@ h1 {
   line-height: 1.6;
 }
 
+.build-info {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+
 .card {
   background: var(--card-bg);
   border-radius: 12px;

--- a/templates/copy.html
+++ b/templates/copy.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <main class="container">
+      <p class="build-info">Última compilación: {{ build_timestamp_label }}</p>
       <header class="page-header">
         <h1>Copiar archivos desde NAS a S3</h1>
         <a href="{{ url_for('menu') }}" class="secondary back-button">Volver al menú</a>

--- a/templates/incluir.html
+++ b/templates/incluir.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <main class="container">
+      <p class="build-info">Última compilación: {{ build_timestamp_label }}</p>
       <header class="page-header">
         <h1>Incluir en base gestor</h1>
         <a href="{{ url_for('menu') }}" class="secondary back-button">Volver al inicio</a>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <main class="container menu-container">
+      <p class="build-info">Última compilación: {{ build_timestamp_label }}</p>
       <h1>Gestor de archivos</h1>
       <p class="intro">
         Seleccioná una operación para comenzar. Podés copiar los archivos disponibles en el NAS hacia el


### PR DESCRIPTION
## Summary
- inject the build timestamp in Flask templates so each page displays the last compilation time at the top
- capture the INSERT statement when database writes fail and surface it in the runtime error message for easier troubleshooting
- style the compilation timestamp banner consistently with the existing UI

## Testing
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d318bbb700832d82830cca7b92b1ef