### PR TITLE
Set original filename when inserting records

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -681,7 +681,7 @@ def _normalize_object_for_table(
         elif lower == "sgddocnombre":
             values.append(name)
         elif lower == "sgddocnombreoriginal":
-            values.append(name)
+            values.append(filename)
         elif lower == "sgddoctipo":
             values.append(cleaned_extension)
         elif lower == "sgddotamano":


### PR DESCRIPTION
## Summary
- ensure sgddocnombreoriginal values use the original S3 object filename when preparing inserts

## Testing
- python -m compileall webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d31f42c510832db30c1ffb31fc9807